### PR TITLE
Remove theme system to eliminate cmap overlap

### DIFF
--- a/src/life/__main__.py
+++ b/src/life/__main__.py
@@ -32,9 +32,6 @@ parser.add_argument(
 )
 
 # Enhanced visualization arguments
-parser.add_argument("--theme", type=str, default="default", 
-                   choices=["default", "neon", "matrix", "ocean", "fire", "cyber"],
-                   help="Visual theme")
 parser.add_argument("--show-grid", action="store_true", help="Show grid lines")
 parser.add_argument("--show-stats", action="store_true", help="Show statistics overlay")
 parser.add_argument("--fullscreen", action="store_true", help="Run in fullscreen mode")
@@ -52,13 +49,8 @@ animator = Animator(
     interval=args.interval, 
     figsize=args.figsize,
     show_grid=args.show_grid,
-    show_stats=args.show_stats,
-    theme=args.theme
+    show_stats=args.show_stats
 )
-
-# Setup matplotlib style
-if args.theme != 'default':
-    plt.style.use('dark_background')
 
 # Create animation
 ani = animator()
@@ -75,7 +67,7 @@ if args.fullscreen:
             pass  # Backend doesn't support fullscreen
 
 print(f"🎮 Conway's Game of Life - Enhanced Edition")
-print(f"📊 Size: {args.size}x{args.size} | Theme: {args.theme} | Function: {args.func}")
+print(f"📊 Size: {args.size}x{args.size} | Colormap: {args.cmap} | Function: {args.func}")
 print(f"🎨 Grid: {'ON' if args.show_grid else 'OFF'} | Stats: {'ON' if args.show_stats else 'OFF'}")
 print(f"⚡ Press Ctrl+C to stop")
 

--- a/src/life/animator.py
+++ b/src/life/animator.py
@@ -1,10 +1,9 @@
 import time
-from typing import Dict, Optional, Tuple
+from typing import Optional, Tuple
 
 import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.colors import LinearSegmentedColormap
 
 from life.life import Life
 
@@ -27,24 +26,12 @@ class Animator:
         Whether to display grid lines (default: False).
     show_stats: bool, optional
         Whether to display statistics overlay (default: False).
-    theme: str, optional
-        Visual theme: 'default', 'neon', 'matrix', 'ocean', 'fire', 'cyber'.
 
     Returns
     -------
     animation.FuncAnimation
         The enhanced animation of the game of life.
     """
-
-    # Predefined visual themes
-    THEMES: Dict[str, Dict] = {
-        'default': {'cmap': 'binary', 'bg_color': 'white'},
-        'neon': {'cmap': 'plasma', 'bg_color': '#0a0a0a'},
-        'matrix': {'cmap': 'Greens', 'bg_color': 'black'},
-        'ocean': {'cmap': 'Blues', 'bg_color': '#001122'},
-        'fire': {'cmap': 'hot', 'bg_color': '#1a0000'},
-        'cyber': {'cmap': 'viridis', 'bg_color': '#0d1117'}
-    }
 
     def __init__(
         self, 
@@ -53,8 +40,7 @@ class Animator:
         interval: int, 
         figsize: int,
         show_grid: bool = False,
-        show_stats: bool = False,
-        theme: str = 'default'
+        show_stats: bool = False
     ) -> None:
         self.life: Life = life
         self.cmap: str = cmap
@@ -62,30 +48,12 @@ class Animator:
         self.figsize: int = figsize
         self.show_grid: bool = show_grid
         self.show_stats: bool = show_stats
-        self.theme: str = theme
         
         # Statistics tracking
         self.generation: int = 0
         self.start_time: float = time.time()
         self.fps_counter: list = []
         self.last_frame_time: float = time.time()
-        
-        # Apply theme if specified
-        if theme in self.THEMES:
-            self.cmap = self.THEMES[theme]['cmap']
-            
-        self._setup_colormap()
-
-    def _setup_colormap(self) -> None:
-        """Setup custom colormap based on theme."""
-        if self.theme == 'matrix':
-            colors = ['#000000', '#003300', '#00ff00']
-            self._custom_cmap = LinearSegmentedColormap.from_list('matrix', colors)
-        elif self.theme == 'neon':
-            colors = ['#000000', '#ff00ff', '#00ffff', '#ffffff']
-            self._custom_cmap = LinearSegmentedColormap.from_list('neon', colors)
-        else:
-            self._custom_cmap = None
 
     def _get_population_stats(self) -> Tuple[int, float]:
         """Calculate population and density statistics."""
@@ -120,19 +88,13 @@ class Animator:
 
     def __call__(self) -> animation.FuncAnimation:
         """Create and return the enhanced animation."""
-        # Setup figure with theme
+        # Setup figure
         fig, ax = plt.subplots(figsize=(self.figsize, self.figsize))
-        if self.theme in self.THEMES:
-            fig.patch.set_facecolor(self.THEMES[self.theme]['bg_color'])
-            ax.set_facecolor(self.THEMES[self.theme]['bg_color'])
-
-        # Use custom colormap if available
-        cmap = self._custom_cmap if self._custom_cmap else self.cmap
         
         # Create enhanced image display
         im = ax.imshow(
             self.life.state, 
-            cmap=cmap, 
+            cmap=self.cmap, 
             interpolation="bilinear",
             vmin=0, 
             vmax=1,
@@ -154,7 +116,7 @@ class Animator:
                 0.02, 0.98, "", transform=ax.transAxes,
                 verticalalignment='top', fontsize=10,
                 bbox=dict(boxstyle="round,pad=0.3", facecolor='black', alpha=0.7),
-                color='lime' if self.theme == 'matrix' else 'white'
+                color='white'
             )
         else:
             plt.axis("off")
@@ -183,10 +145,6 @@ class Animator:
                 )
                 stats_text.set_text(stats_str)
                 title_text.set_text(f"Conway's Game of Life - Gen: {self.generation}")
-            
-            # Add subtle glow effect for certain themes
-            if self.theme in ['neon', 'matrix']:
-                im.set_alpha(0.85 + 0.15 * np.sin(self.generation * 0.1))
             
             return [im] + ([stats_text, title_text] if stats_text else [])
 


### PR DESCRIPTION
## Summary
- Remove the theme system that was overlapping and conflicting with the cmap parameter
- Simplify the interface to use matplotlib colormaps directly
- Eliminate user confusion between --theme and --cmap parameters
- Reduce code complexity while maintaining visual customization

## Problem Addressed
The original implementation had conflicting parameters:
- `--theme matrix --cmap viridis` would ignore viridis and use Greens (from Matrix theme)
- Users couldn't use their preferred colormap when a theme was specified
- Two parameters controlling the same visual aspect created confusion

## Changes Made

### 🗑️ **Removed Components**
- **`--theme` CLI argument** and theme choices
- **`THEMES` dictionary** with predefined theme configurations  
- **Custom colormap generation** (`_setup_colormap` method)
- **Theme-dependent styling** (background colors, glow effects)
- **Theme override logic** that replaced user's cmap choice

### ✨ **Simplified Interface**
- **Direct cmap usage** - parameter works exactly as expected
- **Cleaner console output** showing colormap instead of theme
- **Reduced constructor parameters** in Animator class
- **Streamlined visual pipeline** without theme conflicts

## Usage Examples

### Before (Confusing):
```bash
# cmap gets ignored - uses 'Greens' from Matrix theme
scripts/run.sh --theme matrix --cmap viridis --show-stats

# Only way to use custom cmap was with default theme
scripts/run.sh --theme default --cmap viridis --show-stats
```

### After (Clear):
```bash
# Use any matplotlib colormap directly
scripts/run.sh --cmap viridis --show-stats
scripts/run.sh --cmap plasma --show-grid --size 30
scripts/run.sh --cmap Greens --show-stats  # Matrix-like
scripts/run.sh --cmap hot --fullscreen     # Fire-like
```

## Benefits
✅ **Eliminates parameter conflicts** - cmap works consistently  
✅ **Reduces user confusion** - single parameter for color control  
✅ **Simplifies codebase** - 50 fewer lines of theme logic  
✅ **Better matplotlib integration** - direct colormap usage  
✅ **More flexible** - access to all matplotlib colormaps  

## Breaking Changes
⚠️ **`--theme` argument removed** - users should migrate to `--cmap`  
⚠️ **Theme-specific effects removed** (glow animations, custom backgrounds)  

## Migration Guide
| Old Command | New Command |
|-------------|-------------|
| `--theme matrix` | `--cmap Greens` |
| `--theme neon` | `--cmap plasma` |
| `--theme ocean` | `--cmap Blues` |
| `--theme fire` | `--cmap hot` |
| `--theme cyber` | `--cmap viridis` |

## Test Plan
- [x] Verify cmap parameter works without theme interference
- [x] Test various matplotlib colormaps (viridis, plasma, Greens, hot)
- [x] Confirm statistics and grid display still work
- [x] Validate console output shows correct colormap
- [x] Test fullscreen mode functionality

🤖 Generated with [Claude Code](https://claude.ai/code)